### PR TITLE
Hide SVG

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -202,6 +202,12 @@ const addEventListeners = () => {
       }
     })
   };
+
+  // Hide the SVG element used for colour filter
+  chrome.devtools.inspectedWindow.eval(`
+    var hideSVG = document.createElement("style");
+    hideSVG.innerHTML = "#colorFilterSVG { display: none; }";
+    document.head.appendChild(hideSVG);`);
 }
 
 function severityNode(severity) {


### PR DESCRIPTION
When lens that uses SVG filter is selected, the `<svg>` element is not hidden, so a blank space appears below the footer of the inspected window.