### PR TITLE
Fix a false option and link

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
                   <h2>Using ChromeLens</h2>
 
-                  <p>Install the ChromeLens extension by cloning our git repository (<a href="https://github.com/jin/chromelens">GitHub Link</a>) or downloading from the <a href="https://chrome.google.com/webstore/detail/chrome-lens/idikgljglpfilbhaboonnpnnincjhjkd">Chrome Store</a> and adding the project as an experimental extension. More details on experimental extensions can be found in the following link: <a href="https://developer.chrome.com/extensions/experimental">https://developer.chrome.com/extensions/experimental</a>
+                  <p>Install the ChromeLens extension by cloning our git repository (<a href="https://github.com/jin/chromelens">GitHub Link</a>) or downloading from the <a href="https://chrome.google.com/webstore/detail/chrome-lens/idikgljglpfilbhaboonnpnnincjhjkd">Chrome Store</a> and adding the project as an unpacked extension. More details on unpacked extensions can be found in the following link: <a href="https://developer.chrome.com/extensions/getstarted#unpacked">https://developer.chrome.com/extensions/getstarted#unpacked</a>
                   </p>
               </div>
               <div style="width:280px;float:right;margin: auto;">


### PR DESCRIPTION
Changed the experimental extensions reference to the unpacked extensions reference.

manifest.json does not contain the "experimental" permission (otherwise, the web store would not have accepted it), so there is no reason to follow the experimental extensions instructions (the flag is not needed), unless I am mistaken.