### PR TITLE
Fix #9 #13 + update axs_testing.js

### DIFF
--- a/audit/axs_testing.js
+++ b/audit/axs_testing.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Generated from http://github.com/GoogleChrome/accessibility-developer-tools/tree/582ba71c124ed834d640ce2109dcd91b7864922f
+ * Generated from http://github.com/GoogleChrome/accessibility-developer-tools/tree/7d778f7da58af341a47b3a6f6457c2842b24d4d8
  *
  * See project README for build steps.
  */
@@ -43,28 +43,76 @@ goog.DEBUG = !0;
 goog.LOCALE = "en";
 goog.TRUSTED_SITE = !0;
 goog.STRICT_MODE_COMPATIBLE = !1;
+goog.DISALLOW_TEST_ONLY_CODE = COMPILED && !goog.DEBUG;
+goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING = !1;
 goog.provide = function(a) {
+  if (goog.isInModuleLoader_()) {
+    throw Error("goog.provide can not be used within a goog.module.");
+  }
+  if (!COMPILED && goog.isProvided_(a)) {
+    throw Error('Namespace "' + a + '" already declared.');
+  }
+  goog.constructNamespace_(a);
+};
+goog.constructNamespace_ = function(a, b) {
+  if (!COMPILED) {
+    delete goog.implicitNamespaces_[a];
+    for (var c = a;(c = c.substring(0, c.lastIndexOf("."))) && !goog.getObjectByName(c);) {
+      goog.implicitNamespaces_[c] = !0;
+    }
+  }
+  goog.exportPath_(a, b);
+};
+goog.VALID_MODULE_RE_ = /^[a-zA-Z_$][a-zA-Z0-9._$]*$/;
+goog.module = function(a) {
+  if (!goog.isString(a) || !a || -1 == a.search(goog.VALID_MODULE_RE_)) {
+    throw Error("Invalid module identifier");
+  }
+  if (!goog.isInModuleLoader_()) {
+    throw Error("Module " + a + " has been loaded incorrectly.");
+  }
+  if (goog.moduleLoaderState_.moduleName) {
+    throw Error("goog.module may only be called once per module.");
+  }
+  goog.moduleLoaderState_.moduleName = a;
   if (!COMPILED) {
     if (goog.isProvided_(a)) {
       throw Error('Namespace "' + a + '" already declared.');
     }
     delete goog.implicitNamespaces_[a];
-    for (var b = a;(b = b.substring(0, b.lastIndexOf("."))) && !goog.getObjectByName(b);) {
-      goog.implicitNamespaces_[b] = !0;
-    }
   }
-  goog.exportPath_(a);
+};
+goog.module.get = function(a) {
+  return goog.module.getInternal_(a);
+};
+goog.module.getInternal_ = function(a) {
+  if (!COMPILED) {
+    return goog.isProvided_(a) ? a in goog.loadedModules_ ? goog.loadedModules_[a] : goog.getObjectByName(a) : null;
+  }
+};
+goog.moduleLoaderState_ = null;
+goog.isInModuleLoader_ = function() {
+  return null != goog.moduleLoaderState_;
+};
+goog.module.declareLegacyNamespace = function() {
+  if (!COMPILED && !goog.isInModuleLoader_()) {
+    throw Error("goog.module.declareLegacyNamespace must be called from within a goog.module");
+  }
+  if (!COMPILED && !goog.moduleLoaderState_.moduleName) {
+    throw Error("goog.module must be called prior to goog.module.declareLegacyNamespace.");
+  }
+  goog.moduleLoaderState_.declareLegacyNamespace = !0;
 };
 goog.setTestOnly = function(a) {
-  if (COMPILED && !goog.DEBUG) {
-    throw a = a || "", Error("Importing test-only code into non-debug environment" + a ? ": " + a : ".");
+  if (goog.DISALLOW_TEST_ONLY_CODE) {
+    throw a = a || "", Error("Importing test-only code into non-debug environment" + (a ? ": " + a : "."));
   }
 };
 goog.forwardDeclare = function(a) {
 };
 COMPILED || (goog.isProvided_ = function(a) {
-  return !goog.implicitNamespaces_[a] && goog.isDefAndNotNull(goog.getObjectByName(a));
-}, goog.implicitNamespaces_ = {});
+  return a in goog.loadedModules_ || !goog.implicitNamespaces_[a] && goog.isDefAndNotNull(goog.getObjectByName(a));
+}, goog.implicitNamespaces_ = {"goog.module":!0});
 goog.getObjectByName = function(a, b) {
   for (var c = a.split("."), d = b || goog.global, e;e = c.shift();) {
     if (goog.isDefAndNotNull(d[e])) {
@@ -81,39 +129,43 @@ goog.globalize = function(a, b) {
     c[d] = a[d];
   }
 };
-goog.addDependency = function(a, b, c) {
+goog.addDependency = function(a, b, c, d) {
   if (goog.DEPENDENCIES_ENABLED) {
-    var d;
+    var e;
     a = a.replace(/\\/g, "/");
-    for (var e = goog.dependencies_, f = 0;d = b[f];f++) {
-      e.nameToPath[d] = a, a in e.pathToNames || (e.pathToNames[a] = {}), e.pathToNames[a][d] = !0;
+    var f = goog.dependencies_;
+    d && "boolean" !== typeof d || (d = d ? {module:"goog"} : {});
+    for (var g = 0;e = b[g];g++) {
+      f.nameToPath[e] = a, f.loadFlags[a] = d;
     }
     for (d = 0;b = c[d];d++) {
-      a in e.requires || (e.requires[a] = {}), e.requires[a][b] = !0;
+      a in f.requires || (f.requires[a] = {}), f.requires[a][b] = !0;
     }
   }
 };
 goog.ENABLE_DEBUG_LOADER = !0;
+goog.logToConsole_ = function(a) {
+  goog.global.console && goog.global.console.error(a);
+};
 goog.require = function(a) {
-  if (!COMPILED && !goog.isProvided_(a)) {
+  if (!COMPILED) {
+    goog.ENABLE_DEBUG_LOADER && goog.IS_OLD_IE_ && goog.maybeProcessDeferredDep_(a);
+    if (goog.isProvided_(a)) {
+      return goog.isInModuleLoader_() ? goog.module.getInternal_(a) : null;
+    }
     if (goog.ENABLE_DEBUG_LOADER) {
       var b = goog.getPathFromDeps_(a);
       if (b) {
-        goog.included_[b] = !0;
-        goog.writeScripts_();
-        return;
+        return goog.writeScripts_(b), null;
       }
     }
     a = "goog.require could not find: " + a;
-    goog.global.console && goog.global.console.error(a);
+    goog.logToConsole_(a);
     throw Error(a);
   }
 };
 goog.basePath = "";
 goog.nullFunction = function() {
-};
-goog.identityFunction = function(a, b) {
-  return a;
 };
 goog.abstractMethod = function() {
   throw Error("unimplemented abstract method");
@@ -128,16 +180,21 @@ goog.addSingletonGetter = function(a) {
   };
 };
 goog.instantiatedSingletons_ = [];
+goog.LOAD_MODULE_USING_EVAL = !0;
+goog.SEAL_MODULE_EXPORTS = goog.DEBUG;
+goog.loadedModules_ = {};
 goog.DEPENDENCIES_ENABLED = !COMPILED && goog.ENABLE_DEBUG_LOADER;
-goog.DEPENDENCIES_ENABLED && (goog.included_ = {}, goog.dependencies_ = {pathToNames:{}, nameToPath:{}, requires:{}, visited:{}, written:{}}, goog.inHtmlDocument_ = function() {
+goog.ALWAYS_TRANSPILE = !1;
+goog.NEVER_TRANSPILE = !1;
+goog.DEPENDENCIES_ENABLED && (goog.dependencies_ = {loadFlags:{}, nameToPath:{}, requires:{}, visited:{}, written:{}, deferred:{}}, goog.inHtmlDocument_ = function() {
   var a = goog.global.document;
-  return "undefined" != typeof a && "write" in a;
+  return null != a && "write" in a;
 }, goog.findBasePath_ = function() {
-  if (goog.global.CLOSURE_BASE_PATH) {
+  if (goog.isDef(goog.global.CLOSURE_BASE_PATH)) {
     goog.basePath = goog.global.CLOSURE_BASE_PATH;
   } else {
     if (goog.inHtmlDocument_()) {
-      for (var a = goog.global.document.getElementsByTagName("script"), b = a.length - 1;0 <= b;--b) {
+      for (var a = goog.global.document.getElementsByTagName("SCRIPT"), b = a.length - 1;0 <= b;--b) {
         var c = a[b].src, d = c.lastIndexOf("?"), d = -1 == d ? c.length : d;
         if ("base.js" == c.substr(d - 7, 7)) {
           goog.basePath = c.substr(0, d - 7);
@@ -146,53 +203,204 @@ goog.DEPENDENCIES_ENABLED && (goog.included_ = {}, goog.dependencies_ = {pathToN
       }
     }
   }
-}, goog.importScript_ = function(a) {
-  var b = goog.global.CLOSURE_IMPORT_SCRIPT || goog.writeScriptTag_;
-  !goog.dependencies_.written[a] && b(a) && (goog.dependencies_.written[a] = !0);
-}, goog.writeScriptTag_ = function(a) {
+}, goog.importScript_ = function(a, b) {
+  (goog.global.CLOSURE_IMPORT_SCRIPT || goog.writeScriptTag_)(a, b) && (goog.dependencies_.written[a] = !0);
+}, goog.IS_OLD_IE_ = !(goog.global.atob || !goog.global.document || !goog.global.document.all), goog.importProcessedScript_ = function(a, b, c) {
+  goog.importScript_("", 'goog.retrieveAndExec_("' + a + '", ' + b + ", " + c + ");");
+}, goog.queuedModules_ = [], goog.wrapModule_ = function(a, b) {
+  return goog.LOAD_MODULE_USING_EVAL && goog.isDef(goog.global.JSON) ? "goog.loadModule(" + goog.global.JSON.stringify(b + "\n//# sourceURL=" + a + "\n") + ");" : 'goog.loadModule(function(exports) {"use strict";' + b + "\n;return exports});\n//# sourceURL=" + a + "\n";
+}, goog.loadQueuedModules_ = function() {
+  var a = goog.queuedModules_.length;
+  if (0 < a) {
+    var b = goog.queuedModules_;
+    goog.queuedModules_ = [];
+    for (var c = 0;c < a;c++) {
+      goog.maybeProcessDeferredPath_(b[c]);
+    }
+  }
+}, goog.maybeProcessDeferredDep_ = function(a) {
+  goog.isDeferredModule_(a) && goog.allDepsAreAvailable_(a) && (a = goog.getPathFromDeps_(a), goog.maybeProcessDeferredPath_(goog.basePath + a));
+}, goog.isDeferredModule_ = function(a) {
+  var b = (a = goog.getPathFromDeps_(a)) && goog.dependencies_.loadFlags[a] || {};
+  return a && ("goog" == b.module || goog.needsTranspile_(b.lang)) ? goog.basePath + a in goog.dependencies_.deferred : !1;
+}, goog.allDepsAreAvailable_ = function(a) {
+  if ((a = goog.getPathFromDeps_(a)) && a in goog.dependencies_.requires) {
+    for (var b in goog.dependencies_.requires[a]) {
+      if (!goog.isProvided_(b) && !goog.isDeferredModule_(b)) {
+        return !1;
+      }
+    }
+  }
+  return !0;
+}, goog.maybeProcessDeferredPath_ = function(a) {
+  if (a in goog.dependencies_.deferred) {
+    var b = goog.dependencies_.deferred[a];
+    delete goog.dependencies_.deferred[a];
+    goog.globalEval(b);
+  }
+}, goog.loadModuleFromUrl = function(a) {
+  goog.retrieveAndExec_(a, !0, !1);
+}, goog.loadModule = function(a) {
+  var b = goog.moduleLoaderState_;
+  try {
+    goog.moduleLoaderState_ = {moduleName:void 0, declareLegacyNamespace:!1};
+    var c;
+    if (goog.isFunction(a)) {
+      c = a.call(goog.global, {});
+    } else {
+      if (goog.isString(a)) {
+        c = goog.loadModuleFromSource_.call(goog.global, a);
+      } else {
+        throw Error("Invalid module definition");
+      }
+    }
+    var d = goog.moduleLoaderState_.moduleName;
+    if (!goog.isString(d) || !d) {
+      throw Error('Invalid module name "' + d + '"');
+    }
+    goog.moduleLoaderState_.declareLegacyNamespace ? goog.constructNamespace_(d, c) : goog.SEAL_MODULE_EXPORTS && Object.seal && Object.seal(c);
+    goog.loadedModules_[d] = c;
+  } finally {
+    goog.moduleLoaderState_ = b;
+  }
+}, goog.loadModuleFromSource_ = function(a) {
+  eval(a);
+  return {};
+}, goog.writeScriptSrcNode_ = function(a) {
+  goog.global.document.write('<script type="text/javascript" src="' + a + '">\x3c/script>');
+}, goog.appendScriptSrcNode_ = function(a) {
+  var b = goog.global.document, c = b.createElement("script");
+  c.type = "text/javascript";
+  c.src = a;
+  c.defer = !1;
+  c.async = !1;
+  b.head.appendChild(c);
+}, goog.writeScriptTag_ = function(a, b) {
   if (goog.inHtmlDocument_()) {
-    var b = goog.global.document;
-    if ("complete" == b.readyState) {
+    var c = goog.global.document;
+    if (!goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING && "complete" == c.readyState) {
       if (/\bdeps.js$/.test(a)) {
         return !1;
       }
       throw Error('Cannot write "' + a + '" after document load');
     }
-    b.write('<script type="text/javascript" src="' + a + '">\x3c/script>');
+    if (void 0 === b) {
+      if (goog.IS_OLD_IE_) {
+        var d = " onreadystatechange='goog.onScriptLoad_(this, " + ++goog.lastNonModuleScriptIndex_ + ")' ";
+        c.write('<script type="text/javascript" src="' + a + '"' + d + ">\x3c/script>");
+      } else {
+        goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING ? goog.appendScriptSrcNode_(a) : goog.writeScriptSrcNode_(a);
+      }
+    } else {
+      c.write('<script type="text/javascript">' + b + "\x3c/script>");
+    }
     return !0;
   }
   return !1;
-}, goog.writeScripts_ = function() {
-  function a(e) {
-    if (!(e in d.written)) {
-      if (!(e in d.visited) && (d.visited[e] = !0, e in d.requires)) {
-        for (var g in d.requires[e]) {
-          if (!goog.isProvided_(g)) {
-            if (g in d.nameToPath) {
-              a(d.nameToPath[g]);
+}, goog.needsTranspile_ = function(a) {
+  if (goog.ALWAYS_TRANSPILE) {
+    return !0;
+  }
+  if (goog.NEVER_TRANSPILE) {
+    return !1;
+  }
+  if (!goog.transpiledLanguages_) {
+    goog.transpiledLanguages_ = {es5:!0, es6:!0, "es6-impl":!0};
+    try {
+      goog.transpiledLanguages_.es5 = eval("[1,].length!=1"), eval('(()=>{"use strict";let a={};const X=class{constructor(){}x(z){return new Map([...arguments]).get(z[0])==3}};return new X().x([a,3])})()') && (goog.transpiledLanguages_["es6-impl"] = !1), eval('(()=>{"use strict";class X{constructor(){if(new.target!=String)throw 1;this.x=42}}let q=Reflect.construct(X,[],String);if(q.x!=42||!(q instanceof String))throw 1;for(const a of[2,3]){if(a==2)continue;function f(z={a}){let a=0;return z.a}{function f(){return 0;}}return f()==3}})()') && 
+      (goog.transpiledLanguages_.es6 = !1);
+    } catch (b) {
+    }
+  }
+  return !!goog.transpiledLanguages_[a];
+}, goog.transpiledLanguages_ = null, goog.lastNonModuleScriptIndex_ = 0, goog.onScriptLoad_ = function(a, b) {
+  "complete" == a.readyState && goog.lastNonModuleScriptIndex_ == b && goog.loadQueuedModules_();
+  return !0;
+}, goog.writeScripts_ = function(a) {
+  function b(a) {
+    if (!(a in e.written || a in e.visited)) {
+      e.visited[a] = !0;
+      if (a in e.requires) {
+        for (var f in e.requires[a]) {
+          if (!goog.isProvided_(f)) {
+            if (f in e.nameToPath) {
+              b(e.nameToPath[f]);
             } else {
-              throw Error("Undefined nameToPath for " + g);
+              throw Error("Undefined nameToPath for " + f);
             }
           }
         }
       }
-      e in c || (c[e] = !0, b.push(e));
+      a in d || (d[a] = !0, c.push(a));
     }
   }
-  var b = [], c = {}, d = goog.dependencies_, e;
-  for (e in goog.included_) {
-    d.written[e] || a(e);
+  var c = [], d = {}, e = goog.dependencies_;
+  b(a);
+  for (a = 0;a < c.length;a++) {
+    var f = c[a];
+    goog.dependencies_.written[f] = !0;
   }
-  for (e = 0;e < b.length;e++) {
-    if (b[e]) {
-      goog.importScript_(goog.basePath + b[e]);
+  var g = goog.moduleLoaderState_;
+  goog.moduleLoaderState_ = null;
+  for (a = 0;a < c.length;a++) {
+    if (f = c[a]) {
+      var h = e.loadFlags[f] || {}, k = goog.needsTranspile_(h.lang);
+      "goog" == h.module || k ? goog.importProcessedScript_(goog.basePath + f, "goog" == h.module, k) : goog.importScript_(goog.basePath + f);
     } else {
-      throw Error("Undefined script input");
+      throw goog.moduleLoaderState_ = g, Error("Undefined script input");
     }
   }
+  goog.moduleLoaderState_ = g;
 }, goog.getPathFromDeps_ = function(a) {
   return a in goog.dependencies_.nameToPath ? goog.dependencies_.nameToPath[a] : null;
 }, goog.findBasePath_(), goog.global.CLOSURE_NO_DEPS || goog.importScript_(goog.basePath + "deps.js"));
+goog.normalizePath_ = function(a) {
+  a = a.split("/");
+  for (var b = 0;b < a.length;) {
+    "." == a[b] ? a.splice(b, 1) : b && ".." == a[b] && a[b - 1] && ".." != a[b - 1] ? a.splice(--b, 2) : b++;
+  }
+  return a.join("/");
+};
+goog.loadFileSync_ = function(a) {
+  if (goog.global.CLOSURE_LOAD_FILE_SYNC) {
+    return goog.global.CLOSURE_LOAD_FILE_SYNC(a);
+  }
+  try {
+    var b = new goog.global.XMLHttpRequest;
+    b.open("get", a, !1);
+    b.send();
+    return 0 == b.status || 200 == b.status ? b.responseText : null;
+  } catch (c) {
+    return null;
+  }
+};
+goog.retrieveAndExec_ = function(a, b, c) {
+  if (!COMPILED) {
+    var d = a;
+    a = goog.normalizePath_(a);
+    var e = goog.global.CLOSURE_IMPORT_SCRIPT || goog.writeScriptTag_, f = goog.loadFileSync_(a);
+    if (null == f) {
+      throw Error('Load of "' + a + '" failed');
+    }
+    c && (f = goog.transpile_.call(goog.global, f, a));
+    f = b ? goog.wrapModule_(a, f) : f + ("\n//# sourceURL=" + a);
+    goog.IS_OLD_IE_ ? (goog.dependencies_.deferred[d] = f, goog.queuedModules_.push(d)) : e(a, f);
+  }
+};
+goog.transpile_ = function(a, b) {
+  var c = goog.global.$jscomp;
+  c || (goog.global.$jscomp = c = {});
+  var d = c.transpile;
+  if (!d) {
+    var e = goog.basePath + "transpile.js", f = goog.loadFileSync_(e);
+    f && (eval(f + "\n//# sourceURL=" + e), c = goog.global.$jscomp, d = c.transpile);
+  }
+  d || (d = c.transpile = function(a, b) {
+    goog.logToConsole_(b + " requires transpilation but no transpiler was found.");
+    return a;
+  });
+  return d(a, b);
+};
 goog.typeOf = function(a) {
   var b = typeof a;
   if ("object" == b) {
@@ -262,7 +470,7 @@ goog.hasUid = function(a) {
   return !!a[goog.UID_PROPERTY_];
 };
 goog.removeUid = function(a) {
-  "removeAttribute" in a && a.removeAttribute(goog.UID_PROPERTY_);
+  null !== a && "removeAttribute" in a && a.removeAttribute(goog.UID_PROPERTY_);
   try {
     delete a[goog.UID_PROPERTY_];
   } catch (b) {
@@ -330,10 +538,21 @@ goog.globalEval = function(a) {
     goog.global.execScript(a, "JavaScript");
   } else {
     if (goog.global.eval) {
-      if (null == goog.evalWorksForGlobals_ && (goog.global.eval("var _et_ = 1;"), "undefined" != typeof goog.global._et_ ? (delete goog.global._et_, goog.evalWorksForGlobals_ = !0) : goog.evalWorksForGlobals_ = !1), goog.evalWorksForGlobals_) {
+      if (null == goog.evalWorksForGlobals_) {
+        if (goog.global.eval("var _evalTest_ = 1;"), "undefined" != typeof goog.global._evalTest_) {
+          try {
+            delete goog.global._evalTest_;
+          } catch (d) {
+          }
+          goog.evalWorksForGlobals_ = !0;
+        } else {
+          goog.evalWorksForGlobals_ = !1;
+        }
+      }
+      if (goog.evalWorksForGlobals_) {
         goog.global.eval(a);
       } else {
-        var b = goog.global.document, c = b.createElement("script");
+        var b = goog.global.document, c = b.createElement("SCRIPT");
         c.type = "text/javascript";
         c.defer = !1;
         c.appendChild(b.createTextNode(a));
@@ -366,11 +585,9 @@ goog.setCssNameMapping = function(a, b) {
 };
 !COMPILED && goog.global.CLOSURE_CSS_NAME_MAPPING && (goog.cssNameMapping_ = goog.global.CLOSURE_CSS_NAME_MAPPING);
 goog.getMsg = function(a, b) {
-  var c = b || {}, d;
-  for (d in c) {
-    var e = ("" + c[d]).replace(/\$/g, "$$$$");
-    a = a.replace(new RegExp("\\{\\$" + d + "\\}", "gi"), e);
-  }
+  b && (a = a.replace(/\{\$([^}]+)}/g, function(a, d) {
+    return null != b && d in b ? b[d] : a;
+  }));
   return a;
 };
 goog.getMsgWithFallback = function(a, b) {
@@ -390,7 +607,9 @@ goog.inherits = function(a, b) {
   a.prototype = new c;
   a.prototype.constructor = a;
   a.base = function(a, c, f) {
-    var g = Array.prototype.slice.call(arguments, 2);
+    for (var g = Array(arguments.length - 2), h = 2;h < arguments.length;h++) {
+      g[h - 2] = arguments[h];
+    }
     return b.prototype[c].apply(a, g);
   };
 };
@@ -400,9 +619,16 @@ goog.base = function(a, b, c) {
     throw Error("arguments.caller not defined.  goog.base() cannot be used with strict mode code. See http://www.ecma-international.org/ecma-262/5.1/#sec-C");
   }
   if (d.superClass_) {
-    return d.superClass_.constructor.apply(a, Array.prototype.slice.call(arguments, 1));
+    for (var e = Array(arguments.length - 1), f = 1;f < arguments.length;f++) {
+      e[f - 1] = arguments[f];
+    }
+    return d.superClass_.constructor.apply(a, e);
   }
-  for (var e = Array.prototype.slice.call(arguments, 2), f = !1, g = a.constructor;g;g = g.superClass_ && g.superClass_.constructor) {
+  e = Array(arguments.length - 2);
+  for (f = 2;f < arguments.length;f++) {
+    e[f - 2] = arguments[f];
+  }
+  for (var f = !1, g = a.constructor;g;g = g.superClass_ && g.superClass_.constructor) {
     if (g.prototype[b] === d) {
       f = !0;
     } else {
@@ -417,8 +643,54 @@ goog.base = function(a, b, c) {
   throw Error("goog.base called from a method of one name to a method of a different name");
 };
 goog.scope = function(a) {
+  if (goog.isInModuleLoader_()) {
+    throw Error("goog.scope is not supported within a goog.module.");
+  }
   a.call(goog.global);
 };
+COMPILED || (goog.global.COMPILED = COMPILED);
+goog.defineClass = function(a, b) {
+  var c = b.constructor, d = b.statics;
+  c && c != Object.prototype.constructor || (c = function() {
+    throw Error("cannot instantiate an interface (no constructor defined).");
+  });
+  c = goog.defineClass.createSealingConstructor_(c, a);
+  a && goog.inherits(c, a);
+  delete b.constructor;
+  delete b.statics;
+  goog.defineClass.applyProperties_(c.prototype, b);
+  null != d && (d instanceof Function ? d(c) : goog.defineClass.applyProperties_(c, d));
+  return c;
+};
+goog.defineClass.SEAL_CLASS_INSTANCES = goog.DEBUG;
+goog.defineClass.createSealingConstructor_ = function(a, b) {
+  if (!goog.defineClass.SEAL_CLASS_INSTANCES) {
+    return a;
+  }
+  var c = !goog.defineClass.isUnsealable_(b), d = function() {
+    var b = a.apply(this, arguments) || this;
+    b[goog.UID_PROPERTY_] = b[goog.UID_PROPERTY_];
+    this.constructor === d && c && Object.seal instanceof Function && Object.seal(b);
+    return b;
+  };
+  return d;
+};
+goog.defineClass.isUnsealable_ = function(a) {
+  return a && a.prototype && a.prototype[goog.UNSEALABLE_CONSTRUCTOR_PROPERTY_];
+};
+goog.defineClass.OBJECT_PROTOTYPE_FIELDS_ = "constructor hasOwnProperty isPrototypeOf propertyIsEnumerable toLocaleString toString valueOf".split(" ");
+goog.defineClass.applyProperties_ = function(a, b) {
+  for (var c in b) {
+    Object.prototype.hasOwnProperty.call(b, c) && (a[c] = b[c]);
+  }
+  for (var d = 0;d < goog.defineClass.OBJECT_PROTOTYPE_FIELDS_.length;d++) {
+    c = goog.defineClass.OBJECT_PROTOTYPE_FIELDS_[d], Object.prototype.hasOwnProperty.call(b, c) && (a[c] = b[c]);
+  }
+};
+goog.tagUnsealableClass = function(a) {
+  !COMPILED && goog.defineClass.SEAL_CLASS_INSTANCES && (a.prototype[goog.UNSEALABLE_CONSTRUCTOR_PROPERTY_] = !0);
+};
+goog.UNSEALABLE_CONSTRUCTOR_PROPERTY_ = "goog_defineClass_legacy_unsealable";
 var axs = {};
 axs.browserUtils = {};
 axs.browserUtils.matchSelector = function(a, b) {
@@ -734,36 +1006,43 @@ axs.dom.asElement = function(a) {
   }
   return null;
 };
-axs.dom.composedTreeSearch = function(a, b, c, d) {
+axs.dom.composedTreeSearch = function(a, b, c, d, e) {
   if (a === b) {
     return !0;
   }
   if (a.nodeType == Node.ELEMENT_NODE) {
-    var e = a
+    var f = a
   }
-  var f = !1;
-  if (e && c.preorder && !c.preorder(e)) {
-    return f;
-  }
-  if (e) {
-    var g = e.shadowRoot || e.webkitShadowRoot;
-    if (g) {
-      return f = axs.dom.composedTreeSearch(g, b, c, g), e && c.postorder && !f && c.postorder(e), f;
+  var g = !1;
+  d = Object.create(d);
+  if (f) {
+    var h = f.localName;
+    d.collectIdRefs && (d.idrefs = axs.utils.getReferencedIds(f));
+    if (!d.disabled || "legend" === h && axs.browserUtils.matchSelector(f, "fieldset>legend:first-of-type")) {
+      d.disabled = axs.utils.isElementDisabled(f, !0);
+    }
+    d.hidden || (d.hidden = axs.utils.isElementHidden(f));
+    if (c.preorder && !c.preorder(f, d)) {
+      return g;
+    }
+    var k = f.shadowRoot || f.webkitShadowRoot;
+    if (k) {
+      return d.level++, g = axs.dom.composedTreeSearch(k, b, c, d, k), f && c.postorder && !g && c.postorder(f, d), g;
+    }
+    if ("content" == h) {
+      a = f.getDistributedNodes();
+      for (h = 0;h < a.length && !g;h++) {
+        g = axs.dom.composedTreeSearch(a[h], b, c, d, e);
+      }
+      c.postorder && !g && c.postorder.call(null, f, d);
+      return g;
     }
   }
-  if (e && "content" == e.localName) {
-    a = e.getDistributedNodes();
-    for (g = 0;g < a.length && !f;g++) {
-      f = axs.dom.composedTreeSearch(a[g], b, c, d);
-    }
-    e && c.postorder && !f && c.postorder.call(null, e);
-    return f;
+  for (a = a.firstChild;null != a && !g;) {
+    g = axs.dom.composedTreeSearch(a, b, c, d, e), a = a.nextSibling;
   }
-  for (a = a.firstChild;null != a && !f;) {
-    f = axs.dom.composedTreeSearch(a, b, c, d), a = a.nextSibling;
-  }
-  e && c.postorder && !f && c.postorder.call(null, e);
-  return f;
+  f && c.postorder && !g && c.postorder.call(null, f, d);
+  return g;
 };
 axs.utils = {};
 axs.utils.FOCUSABLE_ELEMENTS_SELECTOR = "input:not([type=hidden]):not([disabled]),select:not([disabled]),textarea:not([disabled]),button:not([disabled]),a[href],iframe,[tabindex]";
@@ -974,16 +1253,19 @@ axs.utils.hasLabel = function(a) {
 axs.utils.isNativelyDisableable = function(a) {
   return a.tagName.toUpperCase() in axs.constants.NATIVELY_DISABLEABLE;
 };
-axs.utils.isElementDisabled = function(a) {
-  if (axs.browserUtils.matchSelector(a, "[aria-disabled=true], [aria-disabled=true] *")) {
+axs.utils.isElementDisabled = function(a, b) {
+  if (axs.browserUtils.matchSelector(a, b ? "[aria-disabled=true]" : "[aria-disabled=true], [aria-disabled=true] *")) {
     return !0;
   }
   if (!axs.utils.isNativelyDisableable(a) || axs.browserUtils.matchSelector(a, "fieldset>legend:first-of-type *")) {
     return !1;
   }
-  for (;null !== a;a = axs.dom.parentElement(a)) {
-    if (axs.utils.isNativelyDisableable(a) && a.hasAttribute("disabled")) {
+  for (var c = a;null !== c;c = axs.dom.parentElement(c)) {
+    if (c.hasAttribute("disabled")) {
       return !0;
+    }
+    if (b) {
+      break;
     }
   }
   return !1;
@@ -1016,7 +1298,7 @@ axs.utils.getRoles = function(a, b) {
   }
   for (var c = c.split(" "), d = {roles:[], valid:!1}, e = 0;e < c.length;e++) {
     var f = c[e], g = axs.constants.ARIA_ROLES[f], f = {name:f};
-    g && !g.abstract ? (f.details = g, d.applied || (d.applied = f), f.valid = d.valid = !0) : f.valid = !1;
+    g && !g["abstract"] ? (f.details = g, d.applied || (d.applied = f), f.valid = d.valid = !0) : f.valid = !1;
     d.roles.push(f);
   }
   return d;
@@ -1225,6 +1507,45 @@ axs.utils.getHtmlIdReferrers = function(a) {
   });
   return a.ownerDocument.querySelectorAll(c.join(","));
 };
+axs.utils.getReferencedIds = function(a) {
+  for (var b = [], c = function(a) {
+    a && (0 < a.indexOf(" ") ? b = b.concat(f.value.split(" ")) : b.push(a));
+  }, d = 0;d < a.attributes.length;d++) {
+    var e = a.tagName.toLowerCase(), f = a.attributes[d];
+    if (f.specified) {
+      var g = f.name, h = g.match(/aria-(.+)/);
+      if (h) {
+        e = axs.constants.ARIA_PROPERTIES[h[1]], !e || "idref" !== e.valueType && "idref_list" !== e.valueType || c(f.value);
+      } else {
+        switch(g) {
+          case "contextmenu":
+          ;
+          case "itemref":
+            c(f.value);
+            break;
+          case "form":
+            "button" != e && "fieldset" != e && "input" != e && "keygen" != e && "label" != e && "object" != e && "output" != e && "select" != e && "textarea" != e || c(f.value);
+            break;
+          case "for":
+            "label" != e && "output" != e || c(f.value);
+            break;
+          case "menu":
+            "button" == e && c(f.value);
+            break;
+          case "list":
+            "input" == e && c(f.value);
+            break;
+          case "command":
+            "menuitem" == e && c(f.value);
+            break;
+          case "headers":
+            "td" != e && "tr" != e || c(f.value);
+        }
+      }
+    }
+  }
+  return b;
+};
 axs.utils.getIdReferrers = function(a) {
   var b = [], c = axs.utils.getHtmlIdReferrers(a);
   c && (b = b.concat(Array.prototype.slice.call(c)));
@@ -1379,16 +1700,7 @@ axs.properties.findTextAlternatives = function(a, b, c, d) {
     b.ariaLabel = f;
   }
   c.hasAttribute("role") && "presentation" == c.getAttribute("role") || (a = axs.properties.getTextFromHostLanguageAttributes(c, b, a, e));
-  if (e && axs.utils.elementIsHtmlControl(c)) {
-    f = c.ownerDocument.defaultView;
-    if (c instanceof f.HTMLInputElement) {
-      var g = c;
-      "text" == g.type && g.value && 0 < g.value.length && (b.controlValue = {text:g.value});
-      "range" == g.type && (b.controlValue = {text:g.value});
-    }
-    c instanceof f.HTMLSelectElement && (b.controlValue = {text:c.value});
-    b.controlValue && (f = b.controlValue, a ? f.unused = !0 : a = f.text);
-  }
+  e && axs.utils.elementIsHtmlControl(c) && (f = c.ownerDocument.defaultView, c instanceof f.HTMLInputElement && ("text" == c.type && c.value && 0 < c.value.length && (b.controlValue = {text:c.value}), "range" == c.type && (b.controlValue = {text:c.value})), c instanceof f.HTMLSelectElement && (b.controlValue = {text:c.value}), b.controlValue && (f = b.controlValue, a ? f.unused = !0 : a = f.text));
   if (e && axs.utils.elementIsAriaWidget(c)) {
     e = c.getAttribute("role");
     "textbox" == e && c.textContent && 0 < c.textContent.length && (b.controlValue = {text:c.textContent});
@@ -1396,15 +1708,15 @@ axs.properties.findTextAlternatives = function(a, b, c, d) {
       c.hasAttribute("aria-valuetext") ? b.controlValue = {text:c.getAttribute("aria-valuetext")} : c.hasAttribute("aria-valuenow") && (b.controlValue = {value:c.getAttribute("aria-valuenow"), text:"" + c.getAttribute("aria-valuenow")});
     }
     if ("menu" == e) {
-      for (var h = c.querySelectorAll("[role=menuitemcheckbox], [role=menuitemradio]"), f = [], g = 0;g < h.length;g++) {
-        "true" == h[g].getAttribute("aria-checked") && f.push(h[g]);
+      for (var g = c.querySelectorAll("[role=menuitemcheckbox], [role=menuitemradio]"), f = [], h = 0;h < g.length;h++) {
+        "true" == g[h].getAttribute("aria-checked") && f.push(g[h]);
       }
       if (0 < f.length) {
-        h = "";
-        for (g = 0;g < f.length;g++) {
-          h += axs.properties.findTextAlternatives(f[g], {}, !0), g < f.length - 1 && (h += ", ");
+        g = "";
+        for (h = 0;h < f.length;h++) {
+          g += axs.properties.findTextAlternatives(f[h], {}, !0), h < f.length - 1 && (g += ", ");
         }
-        b.controlValue = {text:h};
+        b.controlValue = {text:g};
       }
     }
     if ("combobox" == e || "select" == e) {
@@ -1494,7 +1806,7 @@ axs.properties.getTextProperties = function(a) {
   if (0 == Object.keys(b).length && ((a = axs.dom.asElement(a)) && axs.browserUtils.matchSelector(a, "img") && (b.alt = {valid:!1, errorMessage:"No alt value provided"}, a = a.src, "string" == typeof a && (c = a.split("/").pop(), b.filename = {text:c})), !c)) {
     return null;
   }
-  b.hasProperties = Boolean(Object.keys(b).length);
+  b.hasProperties = !!Object.keys(b).length;
   b.computedText = c;
   b.lastWord = axs.properties.getLastWord(c);
   return b;
@@ -1655,55 +1967,65 @@ axs.properties.getNativelySupportedAttributes = function(a) {
   };
 })();
 axs.AuditRule = function(a) {
-  for (var b = !0, c = [], d = 0;d < axs.AuditRule.requiredFields.length;d++) {
-    var e = axs.AuditRule.requiredFields[d];
-    e in a || (b = !1, c.push(e));
+  for (var b = a.opt_requires || {}, c = !0, d = [], e = 0;e < axs.AuditRule.requiredFields.length;e++) {
+    var f = axs.AuditRule.requiredFields[e];
+    f in a || (c = !1, d.push(f));
   }
-  if (!b) {
-    throw "Invalid spec; the following fields were not specified: " + c.join(", ") + "\n" + JSON.stringify(a);
+  if (!c) {
+    throw "Invalid spec; the following fields were not specified: " + d.join(", ") + "\n" + JSON.stringify(a);
   }
   this.name = a.name;
   this.severity = a.severity;
   this.relevantElementMatcher_ = a.relevantElementMatcher;
+  this.isRelevant_ = a.isRelevant || function(a, b) {
+    return !0;
+  };
   this.test_ = a.test;
   this.code = a.code;
   this.heading = a.heading || "";
   this.url = a.url || "";
-  this.requiresConsoleAPI = !!a.opt_requiresConsoleAPI;
+  this.requiresConsoleAPI = !!b.consoleAPI;
+  this.relevantElements = [];
+  this.relatedElements = [];
+  this.collectIdRefs = b.idRefs || !1;
 };
 axs.AuditRule.requiredFields = "name severity relevantElementMatcher test code heading".split(" ");
 axs.AuditRule.NOT_APPLICABLE = {result:axs.constants.AuditResult.NA};
 axs.AuditRule.prototype.addElement = function(a, b) {
   a.push(b);
 };
-axs.AuditRule.collectMatchingElements = function(a, b, c, d) {
-  axs.dom.composedTreeSearch(a, null, {preorder:function(a) {
-    if (d) {
-      for (var f = 0;f < d.length;f++) {
-        if (axs.browserUtils.matchSelector(a, d[f])) {
-          return !1;
-        }
-      }
-    }
-    b(a) && c.push(a);
-    return !0;
-  }});
+axs.AuditRule.prototype.collectMatchingElement = function(a, b) {
+  return this.relevantElementMatcher_(a, b) && b.inScope ? (this.relevantElements.push({element:a, flags:b}), !0) : !1;
+};
+axs.AuditRule.prototype.canRun = function(a) {
+  return this.disabled || !a.withConsoleApi && this.requiresConsoleAPI ? !1 : !0;
+};
+axs.AuditRule.Result = function(a, b) {
+  var c = axs.utils.namedValues(b);
+  c.severity = a.getSeverity(b.name) || c.severity;
+  this.rule = c;
+  this.maxResults = a.maxResults;
+  this.update(axs.constants.AuditResult.NA);
+};
+axs.AuditRule.Result.prototype.update = function(a, b) {
+  if (a === axs.constants.AuditResult.FAIL) {
+    var c = this.elements || (this.elements = []);
+    this.result = a;
+    this.maxResults && this.elements.length >= this.maxResults ? this.resultsTruncated = !0 : b && c.push(b);
+  } else {
+    a === axs.constants.AuditResult.PASS ? (this.elements || (this.elements = []), this.result !== axs.constants.AuditResult.FAIL && (this.result = a)) : this.result || (this.result = a);
+  }
 };
 axs.AuditRule.prototype.run = function(a) {
-  a = a || {};
-  var b = "maxResults" in a ? a.maxResults : null, c = [];
-  axs.AuditRule.collectMatchingElements("scope" in a ? a.scope : document, this.relevantElementMatcher_, c, a.ignoreSelectors);
-  var d = [];
-  if (!c.length) {
-    return {result:axs.constants.AuditResult.NA};
+  try {
+    for (var b = this._options || {}, c = new axs.AuditRule.Result(a, this), d;d = this.relevantElements.shift();) {
+      var e = d.element, f = d.flags;
+      this.isRelevant_(e, f) && (this.test_(e, f, b.config) ? c.update(axs.constants.AuditResult.FAIL, e) : c.update(axs.constants.AuditResult.PASS, e));
+    }
+    return c;
+  } finally {
+    this.relatedElements.length = 0;
   }
-  for (var e = 0;e < c.length && !(null != b && d.length >= b);e++) {
-    var f = c[e];
-    this.test_(f, a.config) && this.addElement(d, f);
-  }
-  a = {result:d.length ? axs.constants.AuditResult.FAIL : axs.constants.AuditResult.PASS, elements:d};
-  e < c.length && (a.resultsTruncated = !0);
-  return a;
 };
 axs.AuditRules = {};
 (function() {
@@ -1728,6 +2050,17 @@ axs.AuditRules = {};
     return b ? d : d.map(function(a) {
       return this.getRule(a);
     }, axs.AuditRules);
+  };
+  axs.AuditRules.getActiveRules = function(a) {
+    var b;
+    b = a.auditRulesToRun && 0 < a.auditRulesToRun.length ? a.auditRulesToRun : axs.AuditRules.getRules(!0);
+    if (a.auditRulesToIgnore) {
+      for (var e = 0;e < a.auditRulesToIgnore.length;e++) {
+        var f = a.auditRulesToIgnore[e];
+        0 > b.indexOf(f) || b.splice(b.indexOf(f), 1);
+      }
+    }
+    return b.map(axs.AuditRules.getRule);
   };
 })();
 axs.AuditResults = function() {
@@ -1776,7 +2109,7 @@ axs.AuditConfiguration = function(a) {
   this.rules_ = {};
   this.maxResults = this.auditRulesToIgnore = this.auditRulesToRun = this.scope = null;
   this.withConsoleApi = !1;
-  this.showUnsupportedRulesWarning = !0;
+  this.showUnsupportedRulesWarning = this.walkDom = !0;
   for (var b in this) {
     this.hasOwnProperty(b) && b in a && (this[b] = a[b]);
   }
@@ -1784,6 +2117,7 @@ axs.AuditConfiguration = function(a) {
   goog.exportProperty(this, "auditRulesToRun", this.auditRulesToRun);
   goog.exportProperty(this, "auditRulesToIgnore", this.auditRulesToIgnore);
   goog.exportProperty(this, "withConsoleApi", this.withConsoleApi);
+  goog.exportProperty(this, "walkDom", this.walkDom);
   goog.exportProperty(this, "showUnsupportedRulesWarning", this.showUnsupportedRulesWarning);
 };
 goog.exportSymbol("axs.AuditConfiguration", axs.AuditConfiguration);
@@ -1816,36 +2150,56 @@ axs.Audit.getRulesCannotRun = function(a) {
 };
 axs.Audit.run = function(a) {
   a = a || new axs.AuditConfiguration;
-  var b = a.withConsoleApi, c = [], d;
-  d = a.auditRulesToRun && 0 < a.auditRulesToRun.length ? a.auditRulesToRun : axs.AuditRules.getRules(!0);
-  if (a.auditRulesToIgnore) {
-    for (var e = 0;e < a.auditRulesToIgnore.length;e++) {
-      var f = a.auditRulesToIgnore[e];
-      0 > d.indexOf(f) || d.splice(d.indexOf(f), 1);
-    }
+  if (!axs.Audit.unsupportedRulesWarningShown && a.showUnsupportedRulesWarning) {
+    var b = axs.Audit.getRulesCannotRun(a);
+    0 < b.length && (console.warn("Some rules cannot be checked using the axs.Audit.run() method call. Use the Chrome plugin to check these rules: " + b.join(", ")), console.warn("To remove this message, pass an AuditConfiguration object to axs.Audit.run() and set configuration.showUnsupportedRulesWarning = false."));
+    axs.Audit.unsupportedRulesWarningShown = !0;
   }
-  !axs.Audit.unsupportedRulesWarningShown && a.showUnsupportedRulesWarning && (e = axs.Audit.getRulesCannotRun(a), 0 < e.length && (console.warn("Some rules cannot be checked using the axs.Audit.run() method call. Use the Chrome plugin to check these rules: " + e.join(", ")), console.warn("To remove this message, pass an AuditConfiguration object to axs.Audit.run() and set configuration.showUnsupportedRulesWarning = false.")), axs.Audit.unsupportedRulesWarningShown = !0);
-  for (e = 0;e < d.length;e++) {
-    var f = d[e], g = axs.AuditRules.getRule(f);
-    if (g && !g.disabled && (b || !g.requiresConsoleAPI)) {
-      var h = {}, k = a.getIgnoreSelectors(g.name);
-      if (0 < k.length || a.scope) {
-        h.ignoreSelectors = k;
-      }
-      k = a.getRuleConfig(g.name);
-      null != k && (h.config = k);
-      a.scope && (h.scope = a.scope);
-      a.maxResults && (h.maxResults = a.maxResults);
-      h = g.run.call(g, h);
-      g = axs.utils.namedValues(g);
-      g.severity = a.getSeverity(f) || g.severity;
-      h.rule = g;
-      c.push(h);
-    }
+  b = axs.AuditRules.getActiveRules(a);
+  a.collectIdRefs = b.some(function(a) {
+    return a.collectIdRefs;
+  });
+  a.scope || (a.scope = document.documentElement);
+  axs.Audit.collectMatchingElements(a, b);
+  for (var c = [], d = 0;d < b.length;d++) {
+    var e = b[d];
+    e.canRun(a) && c.push(e.run(a));
   }
   return c;
 };
 goog.exportSymbol("axs.Audit.run", axs.Audit.run);
+(function() {
+  function a(a, c) {
+    var d = a.getIgnoreSelectors(c.name);
+    if (0 < d.length || a.scope) {
+      this.ignoreSelectors = d;
+    }
+    if (d = a.getRuleConfig(c.name)) {
+      this.config = d;
+    }
+  }
+  axs.Audit.collectMatchingElements = function(b, c) {
+    axs.dom.composedTreeSearch(b.walkDom ? document.documentElement : b.scope, null, {preorder:function(d, e) {
+      e.inScope || (e.inScope = d === b.scope);
+      for (var f = 0;f < c.length;f++) {
+        var g = c[f];
+        g.canRun(b) && (g._options = new a(b, g), e.ignoring[g.name] || (e.ignoring[g.name] = g._options.shouldIgnore(d)) || g.collectMatchingElement(d, e));
+      }
+      return !0;
+    }}, {walkDom:b.walkDom, collectIdRefs:b.collectIdRefs, level:0, ignoring:{}, disabled:!1, hidden:!1});
+  };
+  a.prototype.shouldIgnore = function(a) {
+    var c = this.ignoreSelectors;
+    if (c) {
+      for (var d = 0;d < c.length;d++) {
+        if (axs.browserUtils.matchSelector(a, c[d])) {
+          return !0;
+        }
+      }
+    }
+    return !1;
+  };
+})();
 axs.Audit.auditResults = function(a) {
   for (var b = new axs.AuditResults, c = 0;c < a.length;c++) {
     var d = a[c];
@@ -1857,8 +2211,8 @@ goog.exportSymbol("axs.Audit.auditResults", axs.Audit.auditResults);
 axs.Audit.createReport = function(a, b) {
   var c;
   c = "*** Begin accessibility audit results ***\nAn accessibility audit found " + axs.Audit.auditResults(a).toString();
-  b && (c += "\nFor more information, please see ", c += b);
-  return c += "\n*** End accessibility audit results ***";
+  b && (c = c + "\nFor more information, please see " + b);
+  return c + "\n*** End accessibility audit results ***";
 };
 goog.exportSymbol("axs.Audit.createReport", axs.Audit.createReport);
 axs.Audit.accessibilityErrorMessage = function(a) {
@@ -1971,17 +2325,22 @@ axs.AuditRules.addRule({name:"controlsWithoutLabel", heading:"Controls and media
     }
   }
   return !0;
-}, test:function(a) {
-  if (axs.utils.isElementOrAncestorHidden(a) || "input" == a.tagName.toLowerCase() && "button" == a.type && a.value.length || "button" == a.tagName.toLowerCase() && a.textContent.replace(/^\s+|\s+$/g, "").length || axs.utils.hasLabel(a)) {
+}, test:function(a, b) {
+  if (b.hidden || "input" == a.tagName.toLowerCase() && "button" == a.type && a.value.length || "button" == a.tagName.toLowerCase() && a.textContent.replace(/^\s+|\s+$/g, "").length || axs.utils.hasLabel(a)) {
     return !1;
   }
-  a = axs.properties.findTextAlternatives(a, {});
-  return null === a || "" === a.trim() ? !0 : !1;
+  var c = axs.properties.findTextAlternatives(a, {});
+  return null === c || "" === c.trim() ? !0 : !1;
 }, code:"AX_TEXT_01", ruleName:"Controls and media elements should have labels"});
-axs.AuditRules.addRule({name:"duplicateId", heading:"Any ID referred to via an IDREF must be unique in the DOM", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_02", severity:axs.constants.Severity.SEVERE, relevantElementMatcher:function(a) {
-  return a.hasAttribute("id") ? axs.utils.getIdReferrers(a).some(function(a) {
-    return !axs.utils.isElementOrAncestorHidden(a);
-  }) : !1;
+axs.AuditRules.addRule({name:"duplicateId", heading:"Any ID referred to via an IDREF must be unique in the DOM", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_02", severity:axs.constants.Severity.SEVERE, opt_requires:{idRefs:!0}, relevantElementMatcher:function(a, b) {
+  b.idrefs.length && !b.hidden && this.relatedElements.push({element:a, flags:b});
+  return a.hasAttribute("id") ? !0 : !1;
+}, isRelevant:function(a, b) {
+  var c = a.id, d = b.level;
+  return this.relatedElements.some(function(a) {
+    var b = a.flags.idrefs;
+    return a.flags.level === d && 0 <= b.indexOf(c);
+  });
 }, test:function(a) {
   var b = "[id='" + a.id.replace(/'/g, "\\'") + "']";
   return 1 < a.ownerDocument.querySelectorAll(b).length;
@@ -2000,8 +2359,8 @@ axs.AuditRules.addRule({name:"focusableElementNotVisibleAndNotAriaHidden", headi
   }
   a = axs.properties.findTextAlternatives(a, {});
   return null === a || "" === a.trim() ? !1 : !0;
-}, test:function(a) {
-  if (axs.utils.isElementOrAncestorHidden(a)) {
+}, test:function(a, b) {
+  if (b.hidden) {
     return !1;
   }
   a.focus();
@@ -2012,8 +2371,8 @@ axs.AuditRules.addRule({name:"humanLangMissing", heading:"The web page should ha
 }, test:function(a) {
   return a.lang ? !1 : !0;
 }, code:"AX_HTML_01"});
-axs.AuditRules.addRule({name:"imagesWithoutAltText", heading:"Images should have a text alternative or presentational role", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_02", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a) {
-  return axs.browserUtils.matchSelector(a, "img") && !axs.utils.isElementOrAncestorHidden(a);
+axs.AuditRules.addRule({name:"imagesWithoutAltText", heading:"Images should have a text alternative or presentational role", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_02", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a, b) {
+  return axs.browserUtils.matchSelector(a, "img") && !b.hidden;
 }, test:function(a) {
   if (a.hasAttribute("alt") && "" == a.alt || "presentation" == a.getAttribute("role")) {
     return !1;
@@ -2022,30 +2381,32 @@ axs.AuditRules.addRule({name:"imagesWithoutAltText", heading:"Images should have
   axs.properties.findTextAlternatives(a, b);
   return 0 == Object.keys(b).length ? !0 : !1;
 }, code:"AX_TEXT_02"});
-axs.AuditRules.addRule({name:"linkWithUnclearPurpose", heading:"The purpose of each link should be clear from the link text", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_04", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a) {
-  return axs.browserUtils.matchSelector(a, "a[href]") && !axs.utils.isElementOrAncestorHidden(a);
-}, test:function(a, b) {
-  for (var c = b || {}, d = c.blacklistPhrases || [], e = /\s+/, f = 0;f < d.length;f++) {
-    var g = "^\\s*" + d[f].trim().replace(e, "\\s*") + "s*[^a-z]$";
-    if ((new RegExp(g, "i")).test(a.textContent)) {
+axs.AuditRules.addRule({name:"linkWithUnclearPurpose", heading:"The purpose of each link should be clear from the link text", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_04", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a, b) {
+  return axs.browserUtils.matchSelector(a, "a[href]") && !b.hidden;
+}, test:function(a, b, c) {
+  c = c || {};
+  var d = c.blacklistPhrases || [], e = /\s+/;
+  for (b = 0;b < d.length;b++) {
+    var f = "^\\s*" + d[b].trim().replace(e, "\\s*") + "s*[^a-z]$";
+    if ((new RegExp(f, "i")).test(a.textContent)) {
       return !0;
     }
   }
   c = c.stopwords || "click tap go here learn more this page link about".split(" ");
-  d = axs.properties.findTextAlternatives(a, {});
-  if (null === d || "" === d.trim()) {
+  a = axs.properties.findTextAlternatives(a, {});
+  if (null === a || "" === a.trim()) {
     return !0;
   }
-  d = d.replace(/[^a-zA-Z ]/g, "");
-  for (f = 0;f < c.length;f++) {
-    if (d = d.replace(new RegExp("\\b" + c[f] + "\\b", "ig"), ""), "" == d.trim()) {
+  a = a.replace(/[^a-zA-Z ]/g, "");
+  for (b = 0;b < c.length;b++) {
+    if (a = a.replace(new RegExp("\\b" + c[b] + "\\b", "ig"), ""), "" == a.trim()) {
       return !0;
     }
   }
   return !1;
 }, code:"AX_TEXT_04"});
-axs.AuditRules.addRule({name:"lowContrastElements", heading:"Text elements should have a reasonable contrast ratio", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_color_01", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a) {
-  return axs.properties.hasDirectTextDescendant(a) && !axs.utils.isElementDisabled(a);
+axs.AuditRules.addRule({name:"lowContrastElements", heading:"Text elements should have a reasonable contrast ratio", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_color_01", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a, b) {
+  return !b.disabled && axs.properties.hasDirectTextDescendant(a);
 }, test:function(a) {
   var b = window.getComputedStyle(a, null);
   return (a = axs.utils.getContrastRatioForElementWithComputedStyle(b, a)) && axs.utils.isLowContrast(a, b);
@@ -2059,8 +2420,8 @@ axs.AuditRules.addRule({name:"mainRoleOnInappropriateElement", heading:"role=mai
   a = axs.properties.getTextFromDescendantContent(a);
   return !a || 50 > a.length ? !0 : !1;
 }, code:"AX_ARIA_05"});
-axs.AuditRules.addRule({name:"elementsWithMeaningfulBackgroundImage", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a) {
-  return !axs.utils.isElementOrAncestorHidden(a);
+axs.AuditRules.addRule({name:"elementsWithMeaningfulBackgroundImage", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a, b) {
+  return !b.hidden;
 }, heading:"Meaningful images should not be used in element backgrounds", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_image_01", test:function(a) {
   if (a.textContent && 0 < a.textContent.length) {
     return !1;
@@ -2088,21 +2449,13 @@ axs.AuditRules.addRule({name:"multipleLabelableElementsPerLabel", heading:"A lab
     return !0;
   }
 }, code:"AX_TEXT_03"});
-axs.AuditRules.addRule({name:"nonExistentAriaRelatedElement", heading:"ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_02", severity:axs.constants.Severity.SEVERE, relevantElementMatcher:function(a) {
-  var b = axs.utils.getAriaPropertiesByValueType(["idref", "idref_list"]), b = axs.utils.getSelectorForAriaProperties(b);
-  return axs.browserUtils.matchSelector(a, b);
-}, test:function(a) {
-  for (var b = axs.utils.getAriaPropertiesByValueType(["idref", "idref_list"]), b = axs.utils.getSelectorForAriaProperties(b).split(","), c = 0, d = b.length;c < d;c++) {
-    var e = b[c];
-    if (axs.browserUtils.matchSelector(a, e)) {
-      var e = e.match(/aria-[^\]]+/)[0], f = a.getAttribute(e);
-      if (!axs.utils.getAriaPropertyValue(e, f, a).valid) {
-        return !0;
-      }
-    }
-  }
-  return !1;
-}, code:"AX_ARIA_02"});
+axs.AuditRules.addRule({name:"nonExistentRelatedElement", heading:"Attributes which refer to other elements by ID should refer to elements which exist in the DOM", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_03", severity:axs.constants.Severity.SEVERE, opt_requires:{idRefs:!0}, relevantElementMatcher:function(a, b) {
+  return 0 < b.idrefs.length;
+}, test:function(a, b) {
+  return b.idrefs.some(function(a) {
+    return !document.getElementById(a);
+  });
+}, code:"AX_HTML_03"});
 axs.AuditRules.addRule({name:"pageWithoutTitle", heading:"The web page should have a title that describes topic or purpose", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_title_01", severity:axs.constants.Severity.WARNING, relevantElementMatcher:function(a) {
   return "html" == a.tagName.toLowerCase();
 }, test:function(a) {
@@ -2159,8 +2512,8 @@ axs.AuditRules.addRule({name:"requiredAriaAttributeMissing", heading:"Elements w
     return !0;
   }, code:"AX_ARIA_08"});
 })();
-axs.AuditRules.addRule({name:"roleTooltipRequiresDescribedby", heading:"Elements with role=tooltip should have a corresponding element with aria-describedby", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_02", severity:axs.constants.Severity.SEVERE, relevantElementMatcher:function(a) {
-  return axs.browserUtils.matchSelector(a, "[role=tooltip]") && !axs.utils.isElementOrAncestorHidden(a);
+axs.AuditRules.addRule({name:"roleTooltipRequiresDescribedby", heading:"Elements with role=tooltip should have a corresponding element with aria-describedby", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_02", severity:axs.constants.Severity.SEVERE, relevantElementMatcher:function(a, b) {
+  return axs.browserUtils.matchSelector(a, "[role=tooltip]") && !b.hidden;
 }, test:function(a) {
   a = axs.utils.getAriaIdReferrers(a, "aria-describedby");
   return !a || 0 === a.length;
@@ -2248,8 +2601,8 @@ axs.AuditRules.addRule({name:"tabIndexGreaterThanZero", heading:"Avoid positive 
     return !b;
   }, code:"AX_ARIA_13"});
 })();
-axs.AuditRules.addRule({name:"unfocusableElementsWithOnClick", heading:"Elements with onclick handlers must be focusable", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_02", severity:axs.constants.Severity.WARNING, opt_requiresConsoleAPI:!0, relevantElementMatcher:function(a) {
-  return a instanceof a.ownerDocument.defaultView.HTMLBodyElement || axs.utils.isElementOrAncestorHidden(a) ? !1 : "click" in getEventListeners(a) ? !0 : !1;
+axs.AuditRules.addRule({name:"unfocusableElementsWithOnClick", heading:"Elements with onclick handlers must be focusable", url:"https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_02", severity:axs.constants.Severity.WARNING, opt_requires:{consoleAPI:!0}, relevantElementMatcher:function(a, b) {
+  return a instanceof a.ownerDocument.defaultView.HTMLBodyElement || b.hidden ? !1 : "click" in getEventListeners(a) ? !0 : !1;
 }, test:function(a) {
   return !a.hasAttribute("tabindex") && !axs.utils.isElementImplicitlyFocusable(a) && !a.disabled;
 }, code:"AX_FOCUS_02"});

--- a/audit/run_axs.js
+++ b/audit/run_axs.js
@@ -103,19 +103,19 @@ function tooltipTextNode(rule_violated) {
 }
 
 function getCoordinates(elem) {
-    var box = elem.getBoundingClientRect();
-    var body = document.body;
-    var docEl = document.documentElement;
+  var box = elem.getBoundingClientRect();
+  var body = document.body;
+  var docEl = document.documentElement;
 
-    var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
-    var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+  var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+  var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
 
-    var clientTop = docEl.clientTop || body.clientTop || 0;
-    var clientLeft = docEl.clientLeft || body.clientLeft || 0;
+  var clientTop = docEl.clientTop || body.clientTop || 0;
+  var clientLeft = docEl.clientLeft || body.clientLeft || 0;
 
-    var top  = box.top +  scrollTop - clientTop;
-    var left = box.left + scrollLeft - clientLeft;
-    return { top, left, height: box.height, width: box.width }
+  var top  = box.top +  scrollTop - clientTop;
+  var left = box.left + scrollLeft - clientLeft;
+  return { top, left, height: box.height, width: box.width }
 }
 
 function tooltipNode(offendingEl) {
@@ -157,7 +157,7 @@ function suggestFix(ruleViolated) {
   }
 }
 
-function highlightElementForRuleViolation(el, rule_violated) {
+function highlightElementForRuleViolation(frag, el, rule_violated) {
   const warningId = CHROME_LENS_WARNING_CLASS + '-' + (WARNING_COUNT++);
   idToWarningsMap[warningId] = {el: el, rule: rule_violated}
 
@@ -170,8 +170,7 @@ function highlightElementForRuleViolation(el, rule_violated) {
   const toolTip = tooltipNode(el);
   toolTip.appendChild(tooltipText);
 
-  const base = document.getElementById(CHROME_LENS_BASE_ID).shadowRoot;
-  base.appendChild(toolTip);
+  frag.appendChild(toolTip);
   // we can only position after we append, because tooltipText has no
   // bounding client rect before it gets added to the DOM
   positionTooltip(tooltipText, top, left, height);
@@ -183,14 +182,19 @@ function run() {
   var run_result = axs.Audit.run();
   initDom()
 
+  var frag = document.createDocumentFragment();
+
   run_result.forEach(function(v) {
     // we only want to highlight failures
     if (v.result !== 'FAIL') { return; }
 
     v.elements.forEach(function(el) {
-      highlightElementForRuleViolation(el, v.rule);
+      highlightElementForRuleViolation(frag, el, v.rule);
     })
   })
+
+  var root = document.getElementById(CHROME_LENS_BASE_ID).shadowRoot;
+  root.appendChild(frag);
 
   chrome.runtime.sendMessage({
     type: 'AXS_COMPLETE',

--- a/audit/run_axs.js
+++ b/audit/run_axs.js
@@ -1,9 +1,11 @@
-var BASE_Z = 999999;
+const BASE_Z = 999999;
 var WARNING_COUNT = 0;
-var TOOLTIP_Z = BASE_Z + 1;
-var idToWarningsMap = {}
-var STYLE = `
-  #chrome-lens-base {
+var idToWarningsMap = {};
+var STYLE = `<style>
+  :host {
+    all: initial;
+    contain: style layout size;
+    display: block;
     position: absolute;
     top: 0;
     left: 0;
@@ -25,7 +27,7 @@ var STYLE = `
     padding: 0px 10px 5px 10px;
     border-radius: 2px;
     border: 1px solid black;
-    z-index: ${TOOLTIP_Z};
+    z-index: ${BASE_Z+1};
   }
   .tooltip .tooltip-text .severe {
     color: #c10f0f;
@@ -38,23 +40,17 @@ var STYLE = `
   .tooltip:hover .tooltip-text {
     visibility: visible;
   }
-`;
+</style>`;
 
-var CHROME_LENS_STYLE_ID = 'chrome-lens-style'
 var CHROME_LENS_BASE_ID = 'chrome-lens-base'
 var CHROME_LENS_WARNING_CLASS = 'chrome-lens-warning'
 
 function initDom() {
-  if (!document.getElementById(CHROME_LENS_STYLE_ID)) {
-    const style = document.createElement('style');
-    style.id = CHROME_LENS_STYLE_ID;
-    style.innerHTML = STYLE;
-    document.head.appendChild(style)
-  }
-
   if (!document.getElementById(CHROME_LENS_BASE_ID)) {
     const div = document.createElement('div');
     div.id = CHROME_LENS_BASE_ID;
+    var root = div.attachShadow({mode: 'open'});
+    root.innerHTML = STYLE;
     document.body.appendChild(div);
   }
 }
@@ -174,7 +170,7 @@ function highlightElementForRuleViolation(el, rule_violated) {
   const toolTip = tooltipNode(el);
   toolTip.appendChild(tooltipText);
 
-  const base = document.querySelector('#' + CHROME_LENS_BASE_ID);
+  const base = document.getElementById(CHROME_LENS_BASE_ID).shadowRoot;
   base.appendChild(toolTip);
   // we can only position after we append, because tooltipText has no
   // bounding client rect before it gets added to the DOM

--- a/lenses/filters/lens_achromatomaly.js
+++ b/lenses/filters/lens_achromatomaly.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="achromatomaly"> ' +
   '<feColorMatrix type="matrix" values="0.618,0.320,0.062,0,0,0.163,0.775,0.062,0,0,0.163,0.320,0.516,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_achromatopsia.js
+++ b/lenses/filters/lens_achromatopsia.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="achromatopsia"> ' +
   '<feColorMatrix type="matrix" values="0.299,0.587,0.114,0,0,0.299,0.587,0.114,0,0,0.299,0.587,0.114,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_deuteranomaly.js
+++ b/lenses/filters/lens_deuteranomaly.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="deuteranomaly"> ' +
   '<feColorMatrix type="matrix" values="0.8,0.2,0,0,0,0.258,0.742,0,0,0,0,0.142,0.858,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_deuteranopia.js
+++ b/lenses/filters/lens_deuteranopia.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="deuteranopia"> ' +
   '<feColorMatrix type="matrix" values="0.625,0.375,0,0,0,0.7,0.3,0,0,0,0,0.3,0.7,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_fullblindness.js
+++ b/lenses/filters/lens_fullblindness.js
@@ -14,7 +14,7 @@ var styles = `
 `
 
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
+iDiv.id = 'chromelens-colorFilters';
 iDiv.innerHTML = `<div style="${styles}"></div>`;
 
 document.body.appendChild(iDiv);

--- a/lenses/filters/lens_partialblindness.js
+++ b/lenses/filters/lens_partialblindness.js
@@ -14,7 +14,7 @@ var styles = `
 `
 
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
+iDiv.id = 'chromelens-colorFilters';
 iDiv.innerHTML = `<div style="${styles}"></div>`;
 
 document.body.appendChild(iDiv);

--- a/lenses/filters/lens_partialblindness_medium.js
+++ b/lenses/filters/lens_partialblindness_medium.js
@@ -14,7 +14,7 @@ var styles = `
 `
 
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
+iDiv.id = 'chromelens-colorFilters';
 iDiv.innerHTML = `<div style="${styles}"></div>`;
 
 document.body.appendChild(iDiv);

--- a/lenses/filters/lens_partialblindness_serious.js
+++ b/lenses/filters/lens_partialblindness_serious.js
@@ -14,7 +14,7 @@ var styles = `
 `
 
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
+iDiv.id = 'chromelens-colorFilters';
 iDiv.innerHTML = `<div style="${styles}"></div>`;
 
 document.body.appendChild(iDiv);

--- a/lenses/filters/lens_protanomaly.js
+++ b/lenses/filters/lens_protanomaly.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="protanomaly"> ' +
   '<feColorMatrix type="matrix" values="0.817,0.183,0,0,0,0.333,0.667,0,0,0,0,0.125,0.875,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_protanopia.js
+++ b/lenses/filters/lens_protanopia.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="protanopia"> ' +
   '<feColorMatrix type="matrix" values="0.567,0.433,0,0,0,0.558,0.442,0,0,0,0,0.242,0.758,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_tritanomaly.js
+++ b/lenses/filters/lens_tritanomaly.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="tritanomaly"> ' +
   '<feColorMatrix type="matrix" values="0.967,0.033,0,0,0,0,0.733,0.267,0,0,0,0.183,0.817,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/lens_tritanopia.js
+++ b/lenses/filters/lens_tritanopia.js
@@ -1,6 +1,6 @@
 var iDiv = document.createElement('div');
-iDiv.id = 'colorFilters';
-iDiv.innerHTML = '<svg id="colorFilterSVG" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
+iDiv.id = 'chromelens-colorFilters';
+iDiv.innerHTML = '<svg style="display: none" version="1.1" xmlns="http://www.w3.org/2000/svg" baseProfile="full"> ' +
   '<filter id="tritanopia"> ' +
   '<feColorMatrix type="matrix" values="0.95,0.05,0,0,0,0,0.433,0.567,0,0,0,0.475,0.525,0,0,0,0,0,1,0" in="SourceGraphic" /> ' +
   '</filter> ' +

--- a/lenses/filters/reset.js
+++ b/lenses/filters/reset.js
@@ -1,4 +1,4 @@
-var elem = document.getElementById("colorFilters");
+var elem = document.getElementById("chromelens-colorFilters");
 if (elem) {
   elem.parentElement.removeChild(elem);
 }

--- a/panel.js
+++ b/panel.js
@@ -218,12 +218,6 @@ const addEventListeners = () => {
       }
     })
   };
-
-  // Hide the SVG element used for colour filter
-  chrome.devtools.inspectedWindow.eval(`
-    var hideSVG = document.createElement("style");
-    hideSVG.innerHTML = "#colorFilterSVG { display: none; }";
-    document.head.appendChild(hideSVG);`);
 }
 
 function removeChildren(el) {

--- a/panel.js
+++ b/panel.js
@@ -237,8 +237,7 @@ function severityNode(severity) {
 function showAxsResults(idToWarningsMap) {
   const resultRoot = document.querySelector('#axs-results');
   removeChildren(resultRoot);
-  const ul = document.createElement('ul')
-  resultRoot.appendChild(ul)
+  const ul = document.createElement('ul');
   for (i in idToWarningsMap) {
     var div = document.createElement('li');
     div.classList.add('result-line');
@@ -258,13 +257,9 @@ function showAxsResults(idToWarningsMap) {
 
     div.appendChild(document.createTextNode(' '));
     div.appendChild(link);
-    ul.appendChild(div);
-  }
 
-  for (let i in idToWarningsMap) {
-    const warning = document.getElementById(i);
-    warning.onmouseover = function() {
-      _highlight(warning);
+    div.onmouseover = function() {
+      _highlight(this);
       chrome.runtime.sendMessage({
         type: messageType.HIGHLIGHT_WARNING,
         data: {
@@ -272,9 +267,9 @@ function showAxsResults(idToWarningsMap) {
           warningId: i
         }
       });
-    }
-    warning.onmouseout = function() {
-      _unhighlight(warning);
+    };
+    div.onmouseout = function() {
+      _unhighlight(this);
       chrome.runtime.sendMessage({
         type: messageType.UNHIGHLIGHT_WARNING,
         data: {
@@ -282,8 +277,12 @@ function showAxsResults(idToWarningsMap) {
           warningId: i
         }
       });
-    }
+    };
+  
+    ul.appendChild(div);
   }
+
+  resultRoot.appendChild(ul);
 }
 
 function highlightReportLine(warningId) {


### PR DESCRIPTION
This fix uses [shadow DOM v1](https://developers.google.com/web/fundamentals/getting-started/primers/shadowdom) to prevent styles from leaking out of the element. The only downside is this requires at least Chrome 53, but I assume most users (developers) have access to latest Chrome Stable.